### PR TITLE
switching to pagination for conversation.members + flag to avoid rate limits

### DIFF
--- a/matchy.py
+++ b/matchy.py
@@ -79,7 +79,8 @@ def save_partners(new_pairs: [[str, str]], previous_partners: {str: [str]}):
 #   Returns 
 #       List of slack ids for the users in the channel
 def get_channel_members(channel: str) -> [str]:
-    api_call = slack_client.conversations_members(channel = channel)
+    #overriding default limit=100 to get all channel members regardless of channel size
+    api_call = slack_client.conversations_members(channel = channel, limit=2**32)
     users_id = api_call["members"]
     return users_id
 


### PR DESCRIPTION
There is a `limit` parameter in the `slack_client.conversations_member()` method which defaults to 100. This means that for slack channels with over 100 members only the 100 members returned by the Slack API will get matched. See [here](https://api.slack.com/methods/conversations.members) for docs. I have just set `limit=2**32` to override this behavior. 

Thanks - it is a great Slack Bot btw!

